### PR TITLE
Ensure a normalized URL is printed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ async function run() {
       }
       endGroup();
 
-      const url = `https://${projectId}.web.app`;
+      const url = `https://${projectId}.web.app/`;
       await finish({
         details_url: url,
         conclusion: "success",
@@ -106,7 +106,7 @@ async function run() {
     const urlsListMarkdown =
       urls.length === 1
         ? `[${urls[0]}](${urls[0]})`
-        : urls.map((url) => `- [${url}](${url})`).join("/n");
+        : urls.map((url) => `- [${url}](${url})`).join("\n");
 
     if (token && isPullRequest) {
       await postOrUpdateComment(


### PR DESCRIPTION
`https://example.tld` is not a normalized URL, but `https://example.tld/` (note the slash following the origin) is.

```js
new URL('https://example.tld').toString() === 'https://example.tld/'
```

This patch ensures a normalized URL is used in the GitHub comment.

Drive-by fix: fix /n → \n typo.