### PR TITLE
Remove symbols at end of generated CHANNEL_ID

### DIFF
--- a/src/getChannelId.ts
+++ b/src/getChannelId.ts
@@ -22,9 +22,8 @@ export function getChannelId(configuredChannelId: string, ghContext: Context) {
   if (!!configuredChannelId) {
     tmpChannelId = configuredChannelId;
   } else if (ghContext.payload.pull_request) {
-    // const branchName = ghContext.payload.pull_request.head.ref.substr(0, 20);
-    // tmpChannelId = `pr${ghContext.payload.pull_request.number}-${branchName}`;
-    tmpChannelId = `pr${ghContext.payload.pull_request.number}`;
+    const branchName = ghContext.payload.pull_request.head.ref.substr(0, 20);
+    tmpChannelId = `pr${ghContext.payload.pull_request.number}-${branchName}`;
   }
 
   // Channel IDs can only include letters, numbers, underscores, hyphens, and periods.

--- a/src/getChannelId.ts
+++ b/src/getChannelId.ts
@@ -29,7 +29,10 @@ export function getChannelId(configuredChannelId: string, ghContext: Context) {
 
   // Channel IDs can only include letters, numbers, underscores, hyphens, and periods.
   const invalidCharactersRegex = /[^a-zA-Z0-9_\-\.]/g;
-  const correctedChannelId = tmpChannelId.replace(invalidCharactersRegex, "_");
+  const invalidEndCharactersRegex = /[_\-\.]+$/;
+  const correctedChannelId = tmpChannelId
+    .replace(invalidCharactersRegex, "_")
+    .replace(invalidEndCharactersRegex, "");
   if (correctedChannelId !== tmpChannelId) {
     console.log(
       `ChannelId "${tmpChannelId}" contains unsupported characters. Using "${correctedChannelId}" instead.`

--- a/src/getChannelId.ts
+++ b/src/getChannelId.ts
@@ -22,8 +22,9 @@ export function getChannelId(configuredChannelId: string, ghContext: Context) {
   if (!!configuredChannelId) {
     tmpChannelId = configuredChannelId;
   } else if (ghContext.payload.pull_request) {
-    const branchName = ghContext.payload.pull_request.head.ref.substr(0, 20);
-    tmpChannelId = `pr${ghContext.payload.pull_request.number}-${branchName}`;
+    // const branchName = ghContext.payload.pull_request.head.ref.substr(0, 20);
+    // tmpChannelId = `pr${ghContext.payload.pull_request.number}-${branchName}`;
+    tmpChannelId = `pr${ghContext.payload.pull_request.number}`;
   }
 
   // Channel IDs can only include letters, numbers, underscores, hyphens, and periods.


### PR DESCRIPTION
## Issue

#45 

## Changes

Remove symbols at end of generated CHANNEL_ID.

e.g. `example-branch-` -> `example-branch`, `something_` -> `something`

According to firebase/firebase-tools#2724, this PR is needless, but we can avoid such errors now.

