### PR TITLE
Sign comment with signature based on deploy

### DIFF
--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as crypto from "crypto";
+import { ChannelSuccessResult } from "./deploy";
+
+// Create a stable signature for a deploy used for earmarking.
+export function createDeploySignature(deployResult: ChannelSuccessResult) {
+  const results = Object.values(deployResult.result);
+  const sites = results.map((result) => result.site).sort();
+
+  const hash = crypto.createHash("sha1");
+  sites.forEach((site) => {
+    hash.update(site);
+  });
+  return hash.digest("hex");
+}

--- a/src/postOrUpdateComment.ts
+++ b/src/postOrUpdateComment.ts
@@ -26,9 +26,13 @@ import {
 const BOT_SIGNATURE =
   "<sub>🔥 via [Firebase Hosting GitHub Action](https://github.com/marketplace/actions/deploy-to-firebase-hosting) 🌎</sub>";
 
-export function isCommentByBot(comment): boolean {
-  return comment.user.type === "Bot" && comment.body.includes(BOT_SIGNATURE);
+function createBotCommentIdentifier(signature: string) {
+  return function isCommentByBot(comment): boolean {
+    return comment.user.type === "Bot" && comment.body.includes(signature);
+  };
 }
+
+export const isCommentByBot = createBotCommentIdentifier(BOT_SIGNATURE);
 
 export function getURLsMarkdownFromChannelDeployResult(
   result: ChannelSuccessResult

--- a/src/postOrUpdateComment.ts
+++ b/src/postOrUpdateComment.ts
@@ -71,17 +71,6 @@ export async function postChannelSuccessComment(
   result: ChannelSuccessResult,
   commit: string
 ) {
-  const commentMarkdown = getChannelDeploySuccessComment(result, commit);
-
-  return postOrUpdateComment(github, context, commentMarkdown);
-}
-
-// create a PR comment, or update one if it already exists
-async function postOrUpdateComment(
-  github: GitHub | undefined,
-  context: Context,
-  commentMarkdown: string
-) {
   if (!github) {
     console.log("GitHub object not available. Skipping PR comment.");
     return;
@@ -91,6 +80,8 @@ async function postOrUpdateComment(
     ...context.repo,
     issue_number: context.issue.number,
   };
+
+  const commentMarkdown = getChannelDeploySuccessComment(result, commit);
 
   const comment = {
     ...commentInfo,

--- a/src/postOrUpdateComment.ts
+++ b/src/postOrUpdateComment.ts
@@ -22,6 +22,7 @@ import {
   interpretChannelDeployResult,
   ErrorResult,
 } from "./deploy";
+import { createDeploySignature } from "./hash";
 
 const BOT_SIGNATURE =
   "<sub>🔥 via [Firebase Hosting GitHub Action](https://github.com/marketplace/actions/deploy-to-firebase-hosting) 🌎</sub>";
@@ -48,6 +49,7 @@ export function getChannelDeploySuccessComment(
   result: ChannelSuccessResult,
   commit: string
 ) {
+  const deploySignature = createDeploySignature(result);
   const urlList = getURLsMarkdownFromChannelDeployResult(result);
   const { expireTime } = interpretChannelDeployResult(result);
 
@@ -58,7 +60,9 @@ ${urlList}
 
 <sub>(expires ${new Date(expireTime).toUTCString()})</sub>
 
-${BOT_SIGNATURE}`.trim();
+${BOT_SIGNATURE}
+
+<sub>Sign: ${deploySignature}</sub>`.trim();
 }
 
 export async function postChannelSuccessComment(

--- a/src/postOrUpdateComment.ts
+++ b/src/postOrUpdateComment.ts
@@ -27,13 +27,11 @@ import { createDeploySignature } from "./hash";
 const BOT_SIGNATURE =
   "<sub>🔥 via [Firebase Hosting GitHub Action](https://github.com/marketplace/actions/deploy-to-firebase-hosting) 🌎</sub>";
 
-function createBotCommentIdentifier(signature: string) {
+export function createBotCommentIdentifier(signature: string) {
   return function isCommentByBot(comment): boolean {
     return comment.user.type === "Bot" && comment.body.includes(signature);
   };
 }
-
-export const isCommentByBot = createBotCommentIdentifier(BOT_SIGNATURE);
 
 export function getURLsMarkdownFromChannelDeployResult(
   result: ChannelSuccessResult
@@ -89,6 +87,9 @@ export async function postChannelSuccessComment(
   };
 
   startGroup(`Commenting on PR`);
+  const deploySignature = createDeploySignature(result);
+  const isCommentByBot = createBotCommentIdentifier(deploySignature);
+
   let commentId;
   try {
     const comments = (await github.issues.listComments(commentInfo)).data;

--- a/test/hash.test.ts
+++ b/test/hash.test.ts
@@ -1,0 +1,26 @@
+import {
+  channelSingleSiteSuccess,
+  channelMultiSiteSuccess,
+} from "./samples/cliOutputs";
+import { createDeploySignature } from "../src/hash";
+
+describe("hash", () => {
+  it("Returns stable signature for single site", () => {
+    const signSingle = createDeploySignature(channelSingleSiteSuccess);
+    expect(signSingle).toEqual("ca07ce2c831b1990b78fcf2ecdfe230a486dc973");
+  });
+
+  it("Returns stable signature for multi site", () => {
+    const signMulti1 = createDeploySignature(channelMultiSiteSuccess);
+    expect(signMulti1).toEqual("980f04126fb629deaadace7d6ee8a0628942e3d3");
+
+    const signMulti2 = createDeploySignature({
+      ...channelMultiSiteSuccess,
+      result: {
+        targetX: channelMultiSiteSuccess.result.target2,
+        targetY: channelMultiSiteSuccess.result.target1,
+      },
+    });
+    expect(signMulti2).toEqual("980f04126fb629deaadace7d6ee8a0628942e3d3");
+  });
+});

--- a/test/postOrUpdateComment.test.ts
+++ b/test/postOrUpdateComment.test.ts
@@ -5,12 +5,13 @@ import {
 } from "./samples/comments";
 import {
   getChannelDeploySuccessComment,
-  isCommentByBot,
+  createBotCommentIdentifier,
 } from "../src/postOrUpdateComment";
 import {
   channelSingleSiteSuccess,
   channelMultiSiteSuccess,
 } from "./samples/cliOutputs";
+import { createDeploySignature } from "../src/hash";
 
 describe("postOrUpdateComment", () => {
   it("Creates the expected comment for a single site", () => {
@@ -32,6 +33,8 @@ describe("postOrUpdateComment", () => {
   });
 
   it("Can tell if a comment has been written by itself", () => {
+    const signature = createDeploySignature(channelSingleSiteSuccess);
+    const isCommentByBot = createBotCommentIdentifier(signature);
     const testComment = {
       user: { type: "Bot" },
       body: singleSiteComment,
@@ -40,6 +43,8 @@ describe("postOrUpdateComment", () => {
   });
 
   it("Can tell if a comment has not been written by itself", () => {
+    const signature = createDeploySignature(channelMultiSiteSuccess);
+    const isCommentByBot = createBotCommentIdentifier(signature);
     const testComment = {
       user: { type: "Bot" },
       body: notABotComment,

--- a/test/samples/comments.ts
+++ b/test/samples/comments.ts
@@ -5,7 +5,9 @@ export const multiSiteComment = `Visit the preview URL for this PR (updated for 
 
 <sub>(expires Tue, 27 Oct 2020 21:32:57 GMT)</sub>
 
-<sub>🔥 via [Firebase Hosting GitHub Action](https://github.com/marketplace/actions/deploy-to-firebase-hosting) 🌎</sub>`.trim();
+<sub>🔥 via [Firebase Hosting GitHub Action](https://github.com/marketplace/actions/deploy-to-firebase-hosting) 🌎</sub>
+
+<sub>Sign: 980f04126fb629deaadace7d6ee8a0628942e3d3</sub>`.trim();
 
 export const singleSiteComment = `Visit the preview URL for this PR (updated for commit fe211ff):
 
@@ -14,6 +16,7 @@ export const singleSiteComment = `Visit the preview URL for this PR (updated for
 <sub>(expires Tue, 27 Oct 2020 21:32:57 GMT)</sub>
 
 <sub>🔥 via [Firebase Hosting GitHub Action](https://github.com/marketplace/actions/deploy-to-firebase-hosting) 🌎</sub>
-`.trim();
+
+<sub>Sign: ca07ce2c831b1990b78fcf2ecdfe230a486dc973</sub>`.trim();
 
 export const notABotComment = `I am a comment that was not written by action-hosting-deploy!`;


### PR DESCRIPTION
Earmark Bot comment with signature based on deploy instead of static signature.

Intended to prevent bot from overwriting a comment unintentionally, which can happen if several deploys are run from the same repo.