### PR TITLE
Clarify expiry date reset behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,10 @@ build log.
 
 ### `expires` _{string}_
 
-The length of time the preview channel should remain active.
+The length of time the preview channel should remain active after the last deploy.
 If left blank, the action uses the default expiry of 7 days.
+The expiry date will reset to this value on every new deployment.
+
 
 ### `projectId` _{string}_
 


### PR DESCRIPTION
Makes it clearer that the expiry is only after the last deployment and not an expiry time from the first deployment.