### PR TITLE
Impl: Remove preview channel on pr close

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -30,7 +30,7 @@ jobs:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
           expires: 14d
-          projectId: opensource-test-6b243
+          projectId: action-hosting-deploy-demo
           entryPoint: "./demo"
           removeOnClose: true
       - name: Check outputs

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -14,7 +14,9 @@
 
 name: Deploy Preview
 
-on: pull_request
+on:
+  pull_request:
+    types: [closed, synchronize, reopened, opened]
 
 jobs:
   preview:
@@ -28,8 +30,9 @@ jobs:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
           expires: 14d
-          projectId: action-hosting-deploy-demo
+          projectId: opensource-test-6b243
           entryPoint: "./demo"
+          removeOnClose: true
       - name: Check outputs
         run: |
           echo urls ${{steps.firebase_hosting_preview.outputs.url}}

--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ for more information about deploy targets.
 The location of your [`firebase.json`](https://firebase.google.com/docs/cli#the_firebasejson_file)
 file relative to the root of your repository. Defaults to `.` (the root of your repo).
 
+### `removeOnClose` _{boolean}_
+
+Whether to remove the preview channel(s) once the PR is closed (not the same as when a PR is merged). If this is set to false, the preview channel will be removed on its previously set expiry time.
+
+This option has no effect when channelId is set to live
+
+Default is false
+
 ## Outputs
 
 Values emitted by this action that can be consumed by other actions later in your workflow

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,10 @@ inputs:
       directory"
     default: "."
     required: false
+  removeOnClose:
+    description: "Whether to remove the preview channels after a pull request is closed."
+    default: false
+    required: false
 outputs:
   urls:
     description: The url(s) deployed to

--- a/bin/action.min.js
+++ b/bin/action.min.js
@@ -11232,6 +11232,15 @@ async function deployPreview(gacFilename, deployConfig) {
   const deploymentResult = JSON.parse(deploymentText.trim());
   return deploymentResult;
 }
+async function removePreview(gacFilename, deployConfig) {
+  const {
+    projectId,
+    channelId
+  } = deployConfig;
+  const removeDeployment = await execWithCredentials(["hosting:channel:delete", channelId, "--force"], projectId, gacFilename);
+  const removeResults = JSON.parse(removeDeployment.trim());
+  return removeResults;
+}
 async function deployProductionSite(gacFilename, productionDeployConfig) {
   const {
     projectId,
@@ -11413,6 +11422,7 @@ const token = process.env.GITHUB_TOKEN || core.getInput("repoToken");
 const octokit = token ? github.getOctokit(token) : undefined;
 const entryPoint = core.getInput("entryPoint");
 const target = core.getInput("target");
+const removeOnClose = core.getInput("removeOnClose");
 
 async function run() {
   const isPullRequest = !!github.context.payload.pull_request;
@@ -11447,6 +11457,61 @@ async function run() {
     const gacFilename = await createGacFile(googleApplicationCredentials);
     console.log("Created a temporary file with Application Default Credentials.");
     core.endGroup();
+    const channelId = getChannelId(configuredChannelId, github.context);
+    const {
+      payload: {
+        action
+      }
+    } = github.context; // Checking if the action is trigged by a PR closing
+
+    if (action === "closed") {
+      core.startGroup("Removing preview channel");
+
+      if (!removeOnClose || isProductionDeploy) {
+        await finish({
+          conclusion: "skipped",
+          output: {
+            title: `Skipping removal in production channel, or because removeOnClose option was set to false`
+          }
+        });
+      } else {
+        try {
+          const removeDeployment = await removePreview(gacFilename, {
+            projectId,
+            expires,
+            channelId,
+            target
+          });
+
+          if (removeDeployment.status === "error") {
+            throw Error(removeDeployment.error);
+          }
+
+          const hostname = target ? `${target}.web.app` : `${projectId}.web.app`;
+          const url = `https://${hostname}/`;
+          await finish({
+            details_url: url,
+            conclusion: "success",
+            output: {
+              title: `Preview channel removed`,
+              summary: `Expired preview channel: [${hostname}](${url})`
+            }
+          });
+        } catch (e) {
+          core.setFailed(e.message);
+          await finish({
+            conclusion: "failure",
+            output: {
+              title: "Remove preview failed",
+              summary: `Error: ${e.message}, wait for the expiry date or remove it manually.`
+            }
+          });
+        }
+      }
+
+      core.endGroup();
+      return;
+    }
 
     if (isProductionDeploy) {
       core.startGroup("Deploying to production site");
@@ -11473,7 +11538,6 @@ async function run() {
       return;
     }
 
-    const channelId = getChannelId(configuredChannelId, github.context);
     core.startGroup(`Deploying to Firebase preview channel ${channelId}`);
     const deployment = await deployPreview(gacFilename, {
       projectId,

--- a/bin/action.min.js
+++ b/bin/action.min.js
@@ -11211,7 +11211,7 @@ async function execWithCredentials(args, projectId, gacFilename, debug = false) 
     console.log(e.message);
 
     if (debug === false) {
-      console.log("Retrying deploy with the --debug flag for better error output");
+      console.log("Retrying preview channel action with the --debug flag for better error output");
       await execWithCredentials(args, projectId, gacFilename, true);
     } else {
       throw e;
@@ -11487,14 +11487,10 @@ async function run() {
             throw Error(removeDeployment.error);
           }
 
-          const hostname = target ? `${target}.web.app` : `${projectId}.web.app`;
-          const url = `https://${hostname}/`;
           await finish({
-            details_url: url,
             conclusion: "success",
             output: {
-              title: `Preview channel removed`,
-              summary: `Expired preview channel: [${hostname}](${url})`
+              title: `Preview channel removed`
             }
           });
         } catch (e) {

--- a/bin/action.min.js
+++ b/bin/action.min.js
@@ -11471,7 +11471,8 @@ async function run() {
         await finish({
           conclusion: "skipped",
           output: {
-            title: `Skipping removal in production channel, or because removeOnClose option was set to false`
+            title: `Removal skipped`,
+            summary: `Skipping removal in production channel, or because removeOnClose option was set to false`
           }
         });
       } else {
@@ -11490,7 +11491,8 @@ async function run() {
           await finish({
             conclusion: "success",
             output: {
-              title: `Preview channel removed`
+              title: `Preview channel removed`,
+              summary: `Preview channel for this PR has been removed`
             }
           });
         } catch (e) {

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -119,7 +119,7 @@ async function execWithCredentials(
 
     if (debug === false) {
       console.log(
-        "Retrying deploy with the --debug flag for better error output"
+        "Retrying preview channel action with the --debug flag for better error output"
       );
       await execWithCredentials(args, projectId, gacFilename, true);
     } else {

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -23,6 +23,12 @@ export type SiteDeploy = {
   expireTime: string;
 };
 
+export type SiteRemoval = {
+  site: string;
+  target?: string;
+  url: string;
+};
+
 export type ErrorResult = {
   status: "error";
   error: string;
@@ -50,6 +56,16 @@ export type DeployConfig = {
 export type ProductionDeployConfig = {
   projectId: string;
   target?: string;
+};
+
+export type RemovalSuccessResult = {
+  status: "success";
+  result: { [key: string]: SiteRemoval };
+};
+
+export type RemovalSkippedResult = {
+  status: "skipped";
+  result: { [key: string]: SiteDeploy };
 };
 
 export function interpretChannelDeployResult(
@@ -138,6 +154,26 @@ export async function deployPreview(
     | ErrorResult;
 
   return deploymentResult;
+}
+
+export async function removePreview(
+  gacFilename: string,
+  deployConfig: DeployConfig
+) {
+  const { projectId, channelId } = deployConfig;
+
+  const removeDeployment = await execWithCredentials(
+    ["hosting:channel:delete", channelId, "--force"],
+    projectId,
+    gacFilename
+  );
+
+  const removeResults = JSON.parse(removeDeployment.trim()) as
+    | RemovalSkippedResult
+    | RemovalSuccessResult
+    | ErrorResult;
+
+  return removeResults;
 }
 
 export async function deployProductionSite(

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -27,6 +27,7 @@ export type SiteRemoval = {
   site: string;
   target?: string;
   url: string;
+  expireTime?: string;
 };
 
 export type ErrorResult = {
@@ -60,12 +61,6 @@ export type ProductionDeployConfig = {
 
 export type RemovalSuccessResult = {
   status: "success";
-  result: { [key: string]: SiteRemoval };
-};
-
-export type RemovalSkippedResult = {
-  status: "skipped";
-  result: { [key: string]: SiteDeploy };
 };
 
 export function interpretChannelDeployResult(
@@ -161,7 +156,6 @@ export async function removePreview(
   deployConfig: DeployConfig
 ) {
   const { projectId, channelId } = deployConfig;
-
   const removeDeployment = await execWithCredentials(
     ["hosting:channel:delete", channelId, "--force"],
     projectId,
@@ -169,7 +163,6 @@ export async function removePreview(
   );
 
   const removeResults = JSON.parse(removeDeployment.trim()) as
-    | RemovalSkippedResult
     | RemovalSuccessResult
     | ErrorResult;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,8 @@ async function run() {
         await finish({
           conclusion: "skipped",
           output: {
-            title: `Skipping removal in production channel, or because removeOnClose option was set to false`,
+            title: `Removal skipped`,
+            summary: `Skipping removal in production channel, or because removeOnClose option was set to false`,
           },
         });
       } else {
@@ -121,6 +122,7 @@ async function run() {
             conclusion: "success",
             output: {
               title: `Preview channel removed`,
+              summary: `Preview channel for this PR has been removed`,
             },
           });
         } catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,17 +117,10 @@ async function run() {
             throw Error((removeDeployment as ErrorResult).error);
           }
 
-          const hostname = target
-            ? `${target}.web.app`
-            : `${projectId}.web.app`;
-          const url = `https://${hostname}/`;
-
           await finish({
-            details_url: url,
             conclusion: "success",
             output: {
               title: `Preview channel removed`,
-              summary: `Expired preview channel: [${hostname}](${url})`,
             },
           });
         } catch (e) {

--- a/test/samples/cliOutputs.ts
+++ b/test/samples/cliOutputs.ts
@@ -2,6 +2,7 @@ import {
   ChannelSuccessResult,
   ErrorResult,
   ProductionSuccessResult,
+  RemovalSuccessResult,
 } from "../../src/deploy";
 
 export const commitId = "fe211ff";
@@ -59,4 +60,8 @@ export const liveDeployMultiSiteSuccess: ProductionSuccessResult = {
       "sites/action-hosting-deploy-demo-2/versions/e843c071a09cecbf",
     ],
   },
+};
+
+export const removeDeploymentSuccess: RemovalSuccessResult = {
+  status: "success",
 };


### PR DESCRIPTION
# Description

Happy holidays!

Closes: #60

### [**DEMO/EXAMPLE**](https://github.com/kozr/action-hosting-deploy/pull/5)
The only difference between the demo branch in my fork and this branch is the .github/workflow/deploy-preview.yml. The main branch in my fork already has the preview template so I could test.

Although not completely done with what #60 was asking. I implemented the part where a preview channel would be closed after a PR closes (important to note that for a PR: closed != merged). There [isn't an way](https://github.community/t/trigger-workflow-only-on-pull-request-merge/17359) to detect when a PR is merged unless we detect it from the branch in which it is merged into.

Edit: Found out that "closed" will trigger on PR merge. Hooray, it is what #60 is asking for.

Feedbacks are always welcome.

New things:
**_removePreview_**
Mostly identical to the structure of deployPreview except when parsing the results and the argument.
An extra `--force` flag is added to skip cli prompts
```
  const removeDeployment = await execWithCredentials(
    ["hosting:channel:delete", channelId, "--force"],
    projectId,
    gacFilename
  );
```
I added a couple of tests that are similar to the ones for deployPreview

**_removeOnClose_**
A new flag for the GitHub action to enable this feature, defaults to false.
I documented the relevant information regarding the flag in README.md

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Worked on my forked repo with a new Firebase project

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
