### PR TITLE
docs: Update README to include empty option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,15 @@
 
 A full setup guide can be found [in the Firebase Hosting docs](https://firebase.google.com/docs/hosting/github-integration).
 
-The [Firebase CLI](https://firebase.google.com/docs/cli) can get you set up quickly with a default configuration. Just run:
+The [Firebase CLI](https://firebase.google.com/docs/cli) can get you set up quickly with a default configuration.
 
+- If you've NOT set up Hosting, run this version of the command from the root of your local directory:
+```bash
+firebase init hosting
+```
+
+- If you've ALREADY set up Hosting, then you just need to set up the GitHub Action part of Hosting.
+  Run this version of the command from the root of your local directory:
 ```bash
 firebase init hosting:github
 ```


### PR DESCRIPTION
If using an empty directory `firebase init hosting:github` will fail because there is no existing hosting config.

This PR adds the required command to use in the event hosting is not yet added. This PR also updates the README to match the Firebase [docs](https://firebase.google.com/docs/hosting/github-integration#set-up).