### PR TITLE
Impl: Fallback channel ID

### DIFF
--- a/bin/action.min.js
+++ b/bin/action.min.js
@@ -11265,6 +11265,11 @@ function getChannelId(configuredChannelId, ghContext) {
   } else if (ghContext.payload.pull_request) {
     const branchName = ghContext.payload.pull_request.head.ref.substr(0, 20);
     tmpChannelId = `pr${ghContext.payload.pull_request.number}-${branchName}`;
+  } else {
+    // Fallback so we always have a channel name for preview channel
+    const branchName = ghContext.ref.substr(0, 20).replace("refs/heads/", "");
+    const sha = ghContext.sha.substr(0, 8);
+    tmpChannelId = `commit${sha}-${branchName}`;
   } // Channel IDs can only include letters, numbers, underscores, hyphens, and periods.
 
 

--- a/src/getChannelId.ts
+++ b/src/getChannelId.ts
@@ -24,6 +24,11 @@ export function getChannelId(configuredChannelId: string, ghContext: Context) {
   } else if (ghContext.payload.pull_request) {
     const branchName = ghContext.payload.pull_request.head.ref.substr(0, 20);
     tmpChannelId = `pr${ghContext.payload.pull_request.number}-${branchName}`;
+  } else {
+    // Fallback so we always have a channel name for preview channel
+    const branchName = ghContext.ref.substr(0, 20);
+    const sha = ghContext.sha.substr(0, 8) 
+    tmpChannelId = `commit${sha}-${branchName}`;
   }
 
   // Channel IDs can only include letters, numbers, underscores, hyphens, and periods.

--- a/src/getChannelId.ts
+++ b/src/getChannelId.ts
@@ -26,8 +26,8 @@ export function getChannelId(configuredChannelId: string, ghContext: Context) {
     tmpChannelId = `pr${ghContext.payload.pull_request.number}-${branchName}`;
   } else {
     // Fallback so we always have a channel name for preview channel
-    const branchName = ghContext.ref.substr(0, 20);
-    const sha = ghContext.sha.substr(0, 8) 
+    const branchName = ghContext.ref.substr(0, 20).replace("refs/heads/", "");
+    const sha = ghContext.sha.substr(0, 8);
     tmpChannelId = `commit${sha}-${branchName}`;
   }
 


### PR DESCRIPTION
*Related to Issue: #90* 

This pull request ensures that a preview channel id is always generated by falling back to the branch name and commit sha
Useful for when when a commit is added directly to the development branch which we don't want to go live but yet wish to see the changes of (especially on solo projects where PRs don't make sense in a lot of cases)

The implementation has been tested on my own fork and works