### PR TITLE
Enable firebase ci tokens in actions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ A full setup guide can be found [in the Firebase Hosting docs](https://firebase.
 The [Firebase CLI](https://firebase.google.com/docs/cli) can get you set up quickly with a default configuration.
 
 - If you've NOT set up Hosting, run this version of the command from the root of your local directory:
+
 ```bash
 firebase init hosting
 ```
 
 - If you've ALREADY set up Hosting, then you just need to set up the GitHub Action part of Hosting.
   Run this version of the command from the root of your local directory:
+
 ```bash
 firebase init hosting:github
 ```

--- a/action.yml
+++ b/action.yml
@@ -26,8 +26,11 @@ inputs:
     description: "The GITHUB_TOKEN secret"
     required: false
   firebaseServiceAccount:
-    description: "Firebase service account JSON"
-    required: true
+    description: "Firebase service account JSON. Either this or firebaseCIToken must be set."
+    required: false
+  firebaseCIToken:
+    description: "The token generated from firebase login:ci. Either this or firebaseServiceAccount must be set."
+    required: false
   expires:
     description: "How long should a preview live? See the preview channels docs for options"
     default: "7d"

--- a/bin/action.min.js
+++ b/bin/action.min.js
@@ -11190,7 +11190,13 @@ function interpretChannelDeployResult(deployResult) {
 }
 
 async function execWithCredentials(args, projectId, gacFilename, debug = false) {
-  let deployOutputBuf = [];
+  let deployOutputBuf = []; // This assumes that no generated token will end with .json.
+
+  let credentialToProcess = gacFilename.endsWith(".json") ? {
+    GOOGLE_APPLICATION_CREDENTIALS: gacFilename
+  } : {
+    FIREBASE_TOKEN: gacFilename
+  };
 
   try {
     await exec_2("npx firebase-tools", [...args, ...(projectId ? ["--project", projectId] : []), debug ? "--debug" // gives a more thorough error message
@@ -11202,9 +11208,8 @@ async function execWithCredentials(args, projectId, gacFilename, debug = false) 
 
       },
       env: _extends({}, process.env, {
-        FIREBASE_DEPLOY_AGENT: "action-hosting-deploy",
-        GOOGLE_APPLICATION_CREDENTIALS: gacFilename
-      })
+        FIREBASE_DEPLOY_AGENT: "action-hosting-deploy"
+      }, credentialToProcess)
     });
   } catch (e) {
     console.log(Buffer.concat(deployOutputBuf).toString("utf-8"));
@@ -11404,9 +11409,8 @@ async function postChannelSuccessComment(github, context, result, commit) {
 
 const expires = core.getInput("expires");
 const projectId = core.getInput("projectId");
-const googleApplicationCredentials = core.getInput("firebaseServiceAccount", {
-  required: true
-});
+const googleApplicationCredentials = core.getInput("firebaseServiceAccount");
+const firebaseCIToken = core.getInput("firebaseCIToken");
 const configuredChannelId = core.getInput("channelId");
 const isProductionDeploy = configuredChannelId === "live";
 const token = process.env.GITHUB_TOKEN || core.getInput("repoToken");
@@ -11444,13 +11448,24 @@ async function run() {
 
     core.endGroup();
     core.startGroup("Setting up CLI credentials");
-    const gacFilename = await createGacFile(googleApplicationCredentials);
-    console.log("Created a temporary file with Application Default Credentials.");
+    let credentialInfo = "";
+
+    if (googleApplicationCredentials) {
+      console.log("Google Application Credential is being used.");
+      credentialInfo = await createGacFile(googleApplicationCredentials);
+      console.log("Created a temporary file with Application Default Credentials.");
+    } else if (firebaseCIToken) {
+      console.log("Firebase CI token is being used.");
+      credentialInfo = firebaseCIToken;
+    } else {
+      throw Error("either googleApplicationCredential or firebaseCIToken needs to be set");
+    }
+
     core.endGroup();
 
     if (isProductionDeploy) {
       core.startGroup("Deploying to production site");
-      const deployment = await deployProductionSite(gacFilename, {
+      const deployment = await deployProductionSite(credentialInfo, {
         projectId,
         target
       });
@@ -11475,7 +11490,7 @@ async function run() {
 
     const channelId = getChannelId(configuredChannelId, github.context);
     core.startGroup(`Deploying to Firebase preview channel ${channelId}`);
-    const deployment = await deployPreview(gacFilename, {
+    const deployment = await deployPreview(credentialInfo, {
       projectId,
       expires,
       channelId,

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -74,6 +74,11 @@ async function execWithCredentials(
 ) {
   let deployOutputBuf: Buffer[] = [];
 
+  // This assumes that no generated token will end with .json.
+  let credentialToProcess = gacFilename.endsWith(".json")
+    ? { GOOGLE_APPLICATION_CREDENTIALS: gacFilename }
+    : { FIREBASE_TOKEN: gacFilename };
+
   try {
     await exec(
       "npx firebase-tools",
@@ -93,7 +98,7 @@ async function execWithCredentials(
         env: {
           ...process.env,
           FIREBASE_DEPLOY_AGENT: "action-hosting-deploy",
-          GOOGLE_APPLICATION_CREDENTIALS: gacFilename, // the CLI will automatically authenticate with this env variable set
+          ...credentialToProcess, // the CLI will automatically authenticate with this env variable set
         },
       }
     );


### PR DESCRIPTION
This enables the use of firebase ci tokens in GitHub Actions. This will
allow users that cannot use service account keys to use firebase ci
tokens in their actions to help with their automated deployments to
Firebase hosting.

Fixes #128﻿
