### PR TITLE
Clarify use of `entryPoint` option in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ for more information about deploy targets.
 
 ### `entryPoint` _{string}_
 
-The location of your [`firebase.json`](https://firebase.google.com/docs/cli#the_firebasejson_file)
+The directory containing your [`firebase.json`](https://firebase.google.com/docs/cli#the_firebasejson_file)
 file relative to the root of your repository. Defaults to `.` (the root of your repo).
 
 ## Outputs


### PR DESCRIPTION
The current wording can be misinterpreted as requiring the path to the
`firebase.json` file rather than the directory containing it. The new
wording avoids the possibility for confusion.