### PR TITLE
feat: add configFile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ for more information about deploy targets.
 The directory containing your [`firebase.json`](https://firebase.google.com/docs/cli#the_firebasejson_file)
 file relative to the root of your repository. Defaults to `.` (the root of your repo).
 
+### `configFile` _{string}_
+
+The file path of your [`firebase.json`](https://firebase.google.com/docs/cli#the_firebasejson_file)
+file relative to the entryPoint folder. Defaults to `./firebase.json`.
+
 ## Outputs
 
 Values emitted by this action that can be consumed by other actions later in your workflow

--- a/action.yml
+++ b/action.yml
@@ -50,9 +50,15 @@ inputs:
     required: false
   entryPoint:
     description:
-      "The location of your firebase.json file, relative to the root of your
+      "The base folder location for your firebase.json file, relative to the root of your
       directory"
     default: "."
+    required: false
+  configFile:
+    description:
+      "The file path of your firebase.json file, relative to the entryPoint folder.
+      This will be passed as the --config option to the firebase cli."
+    default: "./firebase.json"
     required: false
 outputs:
   urls:

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -45,11 +45,13 @@ export type DeployConfig = {
   expires: string;
   channelId: string;
   target?: string;
+  configFile?: string;
 };
 
 export type ProductionDeployConfig = {
   projectId: string;
   target?: string;
+  configFile?: string;
 };
 
 export function interpretChannelDeployResult(
@@ -120,7 +122,7 @@ export async function deployPreview(
   gacFilename: string,
   deployConfig: DeployConfig
 ) {
-  const { projectId, channelId, target, expires } = deployConfig;
+  const { projectId, channelId, target, expires, configFile } = deployConfig;
 
   const deploymentText = await execWithCredentials(
     [
@@ -128,6 +130,7 @@ export async function deployPreview(
       channelId,
       ...(target ? ["--only", target] : []),
       ...(expires ? ["--expires", expires] : []),
+      ...(configFile ? ["--config", configFile] : []),
     ],
     projectId,
     gacFilename
@@ -144,10 +147,15 @@ export async function deployProductionSite(
   gacFilename,
   productionDeployConfig: ProductionDeployConfig
 ) {
-  const { projectId, target } = productionDeployConfig;
+  const { projectId, target, configFile } = productionDeployConfig;
 
   const deploymentText = await execWithCredentials(
-    ["deploy", "--only", `hosting${target ? ":" + target : ""}`],
+    [
+      "deploy",
+      ...(configFile ? ["--config", configFile] : []),
+      "--only", 
+      `hosting${target ? ":" + target : ""}`,
+    ],
     projectId,
     gacFilename
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ const token = process.env.GITHUB_TOKEN || getInput("repoToken");
 const octokit = token ? getOctokit(token) : undefined;
 const entryPoint = getInput("entryPoint");
 const target = getInput("target");
+const configFile = getInput("configFile");
 
 async function run() {
   const isPullRequest = !!context.payload.pull_request;
@@ -70,11 +71,13 @@ async function run() {
       }
     }
 
-    if (existsSync("./firebase.json")) {
-      console.log("firebase.json file found. Continuing deploy.");
+    const firebaseConfigFile = configFile || "./firebase.json";
+    if (existsSync(firebaseConfigFile)) {
+      console.log(firebaseConfigFile + " file found. Continuing deploy.");
     } else {
       throw Error(
-        "firebase.json file not found. If your firebase.json file is not in the root of your repo, edit the entryPoint option of this GitHub action."
+        firebaseConfigFile + " file not found. If your firebase.json file is not in the root of your repo, " + 
+        "edit the entryPoint option of this GitHub action or set the configFile option relative to the entryPoint."
       );
     }
     endGroup();
@@ -91,6 +94,7 @@ async function run() {
       const deployment = await deployProductionSite(gacFilename, {
         projectId,
         target,
+        configFile,
       });
       if (deployment.status === "error") {
         throw Error((deployment as ErrorResult).error);
@@ -118,6 +122,7 @@ async function run() {
       expires,
       channelId,
       target,
+      configFile,
     });
 
     if (deployment.status === "error") {

--- a/test/deploy.test.ts
+++ b/test/deploy.test.ts
@@ -126,6 +126,25 @@ describe("deploy", () => {
       expect(deployFlags).toContain("--only");
       expect(deployFlags).toContain("my-second-site");
     });
+
+    it("specifies the config file when one is provided", async () => {
+      // @ts-ignore read-only property
+      exec.exec = jest.fn(fakeExec);
+
+      const config: DeployConfig = {
+        ...baseChannelDeployConfig,
+        configFile: "./firebase.other.json",
+      };
+
+      await deployPreview("my-file", config);
+
+      // Check the arguments that exec was called with
+      // @ts-ignore Jest adds a magic "mock" property
+      const args = exec.exec.mock.calls;
+      const deployFlags = args[0][1];
+      expect(deployFlags).toContain("--config");
+      expect(deployFlags).toContain("./firebase.other.json");
+    });
   });
 
   describe("deploy to live channel", () => {
@@ -148,6 +167,56 @@ describe("deploy", () => {
       expect(deployFlags).toContain("deploy");
       expect(deployFlags).toContain("--only");
       expect(deployFlags).toContain("hosting");
+    });
+
+    it("supports the target option", async () => {
+      // @ts-ignore read-only property
+      exec.exec = jest.fn(fakeExec);
+
+      const deployOutput: ProductionSuccessResult = (await deployProductionSite(
+        "my-file",
+        { 
+          ...baseLiveDeployConfig,
+          target: "my-second-site",
+        }
+      )) as ProductionSuccessResult;
+
+      expect(exec.exec).toBeCalled();
+      expect(deployOutput).toEqual(liveDeploySingleSiteSuccess);
+
+      // Check the arguments that exec was called with
+      // @ts-ignore Jest adds a magic "mock" property
+      const args = exec.exec.mock.calls;
+      const deployFlags = args[0][1];
+      expect(deployFlags).toContain("deploy");
+      expect(deployFlags).toContain("--only");
+      expect(deployFlags).toContain("hosting:my-second-site");
+    });
+    
+    it("supports the configFile option", async () => {
+      // @ts-ignore read-only property
+      exec.exec = jest.fn(fakeExec);
+
+      const deployOutput: ProductionSuccessResult = (await deployProductionSite(
+        "my-file",
+        { 
+          ...baseLiveDeployConfig,
+          configFile: "./firebase.live.json",
+        }
+      )) as ProductionSuccessResult;
+
+      expect(exec.exec).toBeCalled();
+      expect(deployOutput).toEqual(liveDeploySingleSiteSuccess);
+
+      // Check the arguments that exec was called with
+      // @ts-ignore Jest adds a magic "mock" property
+      const args = exec.exec.mock.calls;
+      const deployFlags = args[0][1];
+      expect(deployFlags).toContain("deploy");
+      expect(deployFlags).toContain("--only");
+      expect(deployFlags).toContain("hosting");
+      expect(deployFlags).toContain("--config");
+      expect(deployFlags).toContain("./firebase.live.json");
     });
   });
 });


### PR DESCRIPTION
For projects that use multiple `firebase.json` files, it is essential to be able to specify the name of the file that the cli should use.
This is available as the `--config` option in the firebase CLI.
This PR adds a `configFile` action option to set this parameter.

I opted for the `configFile` option name over `config` to avoid any ambiguity that it should point to a file.