### PR TITLE
Enable use of 'Authenticate to Google Cloud' action #299

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,26 @@ on:
 jobs:
   build_and_preview:
     runs-on: ubuntu-latest
+
+    # Add "id-token" with the intended permissions.
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+      
     steps:
       - uses: actions/checkout@v2
       # Add any build steps here. For example:
       # - run: npm ci && npm run build
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          workload_identity_provider: 'projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider'
+          service_account: 'my-service-account@my-project.iam.gserviceaccount.com'
+
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
           expires: 30d
           projectId: your-Firebase-project-ID
 ```
@@ -72,23 +84,36 @@ on:
 jobs:
   deploy_live_website:
     runs-on: ubuntu-latest
+
+    # Add "id-token" with the intended permissions.
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
     steps:
       - uses: actions/checkout@v2
       # Add any build steps here. For example:
       # - run: npm ci && npm run build
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          workload_identity_provider: 'projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider'
+          service_account: 'my-service-account@my-project.iam.gserviceaccount.com'
+
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
           projectId: your-Firebase-project-ID
           channelId: live
 ```
 
 ## Options
 
-### `firebaseServiceAccount` _{string}_ (required)
+### `firebaseServiceAccount` _{string}_
 
 This is a service account JSON key. The easiest way to set it up is to run `firebase init hosting:github`. However, it can also be [created manually](./docs/service-account.md).
+Can be used as a replacement for the [Authenticate to Google Cloud](https://github.com/marketplace/actions/authenticate-to-google-cloud) step.
 
 It's important to store this token as an
 [encrypted secret](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -77,6 +77,11 @@ async function execWithCredentials(
   let deployOutputBuf: Buffer[] = [];
   const debug = opts.debug || false;
   const firebaseToolsVersion = opts.firebaseToolsVersion || "latest";
+  const env = {
+    ...process.env,
+    FIREBASE_DEPLOY_AGENT: "action-hosting-deploy",
+  };
+  if (gacFilename) env['GOOGLE_APPLICATION_CREDENTIALS'] = gacFilename; // the CLI will automatically authenticate with this env variable set
 
   try {
     await exec(
@@ -94,11 +99,7 @@ async function execWithCredentials(
             deployOutputBuf.push(data);
           },
         },
-        env: {
-          ...process.env,
-          FIREBASE_DEPLOY_AGENT: "action-hosting-deploy",
-          GOOGLE_APPLICATION_CREDENTIALS: gacFilename, // the CLI will automatically authenticate with this env variable set
-        },
+        env: env,
       }
     );
   } catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,9 +40,7 @@ import {
 // Inputs defined in action.yml
 const expires = getInput("expires");
 const projectId = getInput("projectId");
-const googleApplicationCredentials = getInput("firebaseServiceAccount", {
-  required: true,
-});
+const googleApplicationCredentials = getInput("firebaseServiceAccount");
 const configuredChannelId = getInput("channelId");
 const isProductionDeploy = configuredChannelId === "live";
 const token = process.env.GITHUB_TOKEN || getInput("repoToken");
@@ -80,12 +78,19 @@ async function run() {
     }
     endGroup();
 
-    startGroup("Setting up CLI credentials");
-    const gacFilename = await createGacFile(googleApplicationCredentials);
-    console.log(
-      "Created a temporary file with Application Default Credentials."
-    );
-    endGroup();
+    let gacFilename;
+    if (googleApplicationCredentials) {
+      startGroup("Setting up CLI credentials");
+      gacFilename = await createGacFile(googleApplicationCredentials);
+      console.log(
+        "Created a temporary file with Application Default Credentials."
+      );
+      endGroup();
+    } else if (!process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+      throw Error(
+        "Unable to authenticate. Please specify 'firebaseServiceAccount' or make sure 'GOOGLE_APPLICATION_CREDENTIALS' environment variable is set."
+      );
+    }
 
     if (isProductionDeploy) {
       startGroup("Deploying to production site");


### PR DESCRIPTION
Reimplementing https://github.com/FirebaseExtended/action-hosting-deploy/pull/299 - 
> Makes the firebaseServiceAccount optional so that GOOGLE_APPLICATION_CREDENTIALS doesn't get overwritten if the option is not defined.
Updated the readme examples to use 'Authenticate to Google Cloud' action with workload identity federation.


I still need to confirm this works as intended - 