### PR TITLE
add debug option

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -45,6 +45,7 @@ type DeployConfig = {
   target?: string;
   // Optional version specification for firebase-tools. Defaults to `latest`.
   firebaseToolsVersion?: string;
+  debug?: boolean;
 };
 
 export type ChannelDeployConfig = DeployConfig & {
@@ -70,8 +71,8 @@ export function interpretChannelDeployResult(
 
 async function execWithCredentials(
   args: string[],
-  projectId,
-  gacFilename,
+  projectId: string,
+  gacFilename: string,
   opts: { debug?: boolean; firebaseToolsVersion?: string }
 ) {
   let deployOutputBuf: Buffer[] = [];
@@ -127,7 +128,7 @@ export async function deployPreview(
   gacFilename: string,
   deployConfig: ChannelDeployConfig
 ) {
-  const { projectId, channelId, target, expires, firebaseToolsVersion } =
+  const { projectId, channelId, target, expires, firebaseToolsVersion, debug } =
     deployConfig;
 
   const deploymentText = await execWithCredentials(
@@ -139,7 +140,7 @@ export async function deployPreview(
     ],
     projectId,
     gacFilename,
-    { firebaseToolsVersion }
+    { firebaseToolsVersion, debug }
   );
 
   const deploymentResult = JSON.parse(deploymentText.trim()) as
@@ -150,16 +151,17 @@ export async function deployPreview(
 }
 
 export async function deployProductionSite(
-  gacFilename,
+  gacFilename: string,
   productionDeployConfig: ProductionDeployConfig
 ) {
-  const { projectId, target, firebaseToolsVersion } = productionDeployConfig;
+  const { projectId, target, firebaseToolsVersion, debug } =
+    productionDeployConfig;
 
   const deploymentText = await execWithCredentials(
     ["deploy", "--only", `hosting${target ? ":" + target : ""}`],
     projectId,
     gacFilename,
-    { firebaseToolsVersion }
+    { firebaseToolsVersion, debug }
   );
 
   const deploymentResult = JSON.parse(deploymentText) as

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@
 
 import {
   endGroup,
+  getBooleanInput,
   getInput,
   setFailed,
   setOutput,
@@ -50,6 +51,7 @@ const octokit = token ? getOctokit(token) : undefined;
 const entryPoint = getInput("entryPoint");
 const target = getInput("target");
 const firebaseToolsVersion = getInput("firebaseToolsVersion");
+const debug = getBooleanInput("debug");
 
 async function run() {
   const isPullRequest = !!context.payload.pull_request;
@@ -93,6 +95,7 @@ async function run() {
         projectId,
         target,
         firebaseToolsVersion,
+        debug,
       });
       if (deployment.status === "error") {
         throw Error((deployment as ErrorResult).error);
@@ -121,6 +124,7 @@ async function run() {
       channelId,
       target,
       firebaseToolsVersion,
+      debug,
     });
 
     if (deployment.status === "error") {


### PR DESCRIPTION
Add a debug option that can be used in the deploy config to enable debug mode on `firebase-tools` in all deployments(preview/prod). 

Currently we're having issues in a project and the only error we have is `Error: Unexpected token p in JSON at position 4`. 
<img width="597" alt="Screenshot 2023-12-05 at 23 42 12" src="https://github.com/FirebaseExtended/action-hosting-deploy/assets/83593673/ed8a5968-1fab-4e29-89e5-dc25862a7a53">

This only happens in the GitHub action, not always but quite often, forcing us to manually re-run the failed action, then it magically works. The retry feature isn't being done for some reason and we don't have a clue where the error comes from, but it happens during the deploy process of firebase-tools per the logs.

Additionally, I added some missing types.

Closes #34.

## TODOs
- [ ] test action
- [ ] document in README


