### PR TITLE
Remove `repoToken` in live channel deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -13,7 +13,6 @@ jobs:
       # - run: npm run build
       - uses: ./
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
           channelId: live
           projectId: action-hosting-deploy-demo

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ jobs:
       # - run: npm ci && npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
           projectId: your-Firebase-project-ID
           channelId: live


### PR DESCRIPTION
In the case of deploying to the live channel, it seems that `repoToken` is not being used based on the code. Therefore, I have removed it.