### PR TITLE
Keep GitHub Actions up to date with Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,7 +10,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-      day: "Monday"
+      day: "monday"
   - package-ecosystem: github-actions
     directory: /
     groups:
@@ -19,4 +19,4 @@ updates:
           - "*"  # Group all Actions updates into a single larger pull request
     schedule:
       interval: weekly
-      day: "Monday"
+      day: monday

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,10 +1,22 @@
 # Please see the documentation for all configuration options:
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
+# Keep GitHub Actions up to date with GitHub's Dependabot...
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
 version: 2
 updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "Monday"
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly
+      day: "Monday"


### PR DESCRIPTION
Fixes #244
Fixes #245
Fixes #341 
* #244
* #245
* #341 

Related to #340
* #340
---
Auto-generates pull requests like alexmojaki/futurecoder#454 to update GitHub Actions which should remove the warnings at the bottom right of https://github.com/FirebaseExtended/action-hosting-deploy/actions/runs/7790497145
* https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
* https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem