### PR TITLE
Add permission documentation for GITHUB_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ this secret yourself - GitHub sets it automatically.
 If you omit this option, you'll need to find the preview URL in the action's
 build log.
 
+For this to work your `GITHUB_TOKEN` permissions must be set to "Read and write permissions". This is set in your repository settings under `Actions > General > Workflow permissions`.
+
 ### `expires` _{string}_
 
 The length of time the preview channel should remain active after the last deploy.


### PR DESCRIPTION
When following the docs verbatim, Github Actions fail with a `403` error since the default setting of the `GITHUB_TOKEN` is read-only.