### PR TITLE
feat(totalPreviewChannelLimit): add option to manage preview channels to avoid hitting the channel quota

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx lint-staged
+npm test && npm run lint-staged

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -13,3 +13,4 @@
 # limitations under the License.
 
 singleQuote: false
+trailingComma: none

--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ The version of `firebase-tools` to use. If not specified, defaults to `latest`.
 
 Disable commenting in a PR with the preview URL.
 
+### `totalPreviewChannelLimit` _{number}_
+
+Specifies the maximum number of preview channels allowed to optimize resource usage or avoid exceeding Firebase Hosting’s quota.
+
+Once the limit is reached, the oldest channels are automatically removed to prevent errors like "Couldn't create channel on [project]: channel quota reached", ensuring smooth deployments.
+
+Currently, **50** preview channels are allowed per Firebase project, including the default "live" site and any additional "live" sites. _totalPreviewChannelLimit = 50 - number of "live sites"_
+
 ## Outputs
 
 Values emitted by this action that can be consumed by other actions later in your workflow

--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ Disable commenting in a PR with the preview URL.
 
 Specifies the maximum number of preview channels allowed to optimize resource usage or avoid exceeding Firebase Hosting’s quota.
 
-Once the limit is reached, the oldest channels are automatically removed to prevent errors like "Couldn't create channel on [project]: channel quota reached", ensuring smooth deployments.
+Once the limit is reached, the oldest channels are automatically removed to prevent errors like "429, Couldn't create channel on [project]: channel quota reached", ensuring smooth deployments.
 
-Currently, **50** preview channels are allowed per Firebase project, including the default "live" site and any additional "live" sites. _totalPreviewChannelLimit = 50 - number of "live sites"_
+Currently, **50** channels are allowed per Hosting **site**, including the default "live" site.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,10 @@ inputs:
       Disable auto-commenting with the preview channel URL to the pull request
     default: "false"
     required: false
+  totalPreviewChannelLimit:
+    description: >-
+      Defines the maximum number of preview channels allowed in a Firebase project
+    required: false
 outputs:
   urls:
     description: The url(s) deployed to

--- a/bin/action.min.js
+++ b/bin/action.min.js
@@ -92974,6 +92974,8 @@ function extractChannelIdFromChannelName(channelName) {
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const SITE_CHANNEL_QUOTA = 50;
+const SITE_CHANNEL_LIVE_SITE = 1;
 function interpretChannelDeployResult(deployResult) {
   const allSiteResults = Object.values(deployResult.result);
   const expireTime = allSiteResults[0].expireTime;
@@ -93036,19 +93038,40 @@ async function getAllChannels(gacFilename, deployConfig) {
   }
 }
 function getPreviewChannelToRemove(channels, totalPreviewChannelLimit) {
-  // Filter out live channel(hosting default site) and channels without an expireTime(additional sites)
-  const previewChannelsOnly = channels.filter(channel => {
-    var _channel$labels;
-    return (channel == null || (_channel$labels = channel.labels) == null ? void 0 : _channel$labels.type) !== "live" && !!(channel != null && channel.expireTime);
-  });
-  if (previewChannelsOnly.length) {
-    // Sort preview channels by expireTime
-    const sortedPreviewChannels = previewChannelsOnly.sort((channelA, channelB) => {
-      return new Date(channelA.expireTime).getTime() - new Date(channelB.expireTime).getTime();
+  let totalAllowedPreviewChannels = totalPreviewChannelLimit;
+  let totalPreviewChannelToSlice = totalPreviewChannelLimit;
+  if (totalPreviewChannelLimit >= SITE_CHANNEL_QUOTA - SITE_CHANNEL_LIVE_SITE) {
+    /**
+     * If the total number of preview channels is greater than or equal to the site channel quota,
+     * preview channels is the site channel quota minus the live site channel
+     *
+     * e.g. 49(total allowed preview channels) = 50(quota) - 1(live site channel)
+     */
+    totalAllowedPreviewChannels = totalPreviewChannelLimit - SITE_CHANNEL_LIVE_SITE;
+    /**
+     * If the total number of preview channels is greater than or equal to the site channel quota,
+     * total preview channels to slice is the site channel quota plus the live site channel plus the current preview deploy
+     *
+     * e.g. 52(total preview channels to slice) = 50(site channel quota) + 1(live site channel) + 1 (current preview deploy)
+     */
+    totalPreviewChannelToSlice = SITE_CHANNEL_QUOTA + SITE_CHANNEL_LIVE_SITE + 1;
+  }
+  if (channels.length > totalAllowedPreviewChannels) {
+    // If the total number of channels exceeds the limit, remove the preview channels
+    // Filter out live channel(hosting default site) and channels without an expireTime(additional sites)
+    const previewChannelsOnly = channels.filter(channel => {
+      var _channel$labels;
+      return (channel == null || (_channel$labels = channel.labels) == null ? void 0 : _channel$labels.type) !== "live" && !!(channel != null && channel.expireTime);
     });
-    // If the total number of preview channels exceeds the limit, return the ones with earlier expireTime
-    if (sortedPreviewChannels.length > totalPreviewChannelLimit) {
-      return sortedPreviewChannels.slice(0, sortedPreviewChannels.length - totalPreviewChannelLimit);
+    if (previewChannelsOnly.length) {
+      // Sort preview channels by expireTime
+      const sortedPreviewChannels = previewChannelsOnly.sort((channelA, channelB) => {
+        return new Date(channelA.expireTime).getTime() - new Date(channelB.expireTime).getTime();
+      });
+      // Calculate the number of preview channels to remove
+      const sliceEnd = totalPreviewChannelToSlice > sortedPreviewChannels.length ? totalPreviewChannelToSlice - sortedPreviewChannels.length : sortedPreviewChannels.length - totalPreviewChannelToSlice;
+      // Remove the oldest preview channels
+      return sortedPreviewChannels.slice(0, sliceEnd);
     }
   } else {
     return [];

--- a/bin/action.min.js
+++ b/bin/action.min.js
@@ -93102,14 +93102,21 @@ async function removePreviews({
     }));
   }
 }
-function removeChannel(gacFilename, deployConfig, channelId) {
+async function removeChannel(gacFilename, deployConfig, channelId) {
   const {
     projectId,
+    target,
     firebaseToolsVersion
   } = deployConfig;
-  return execWithCredentials(["hosting:channel:delete", channelId, "--force"], projectId, gacFilename, {
+  const deleteChannelText = await execWithCredentials(["hosting:channel:delete", channelId, ...(target ? ["--site", target] : []), "--force"], projectId, gacFilename, {
     firebaseToolsVersion
   });
+  const channelResults = JSON.parse(deleteChannelText.trim());
+  if (channelResults.status === "error") {
+    throw Error(channelResults.error);
+  } else {
+    return channelResults.status || "success";
+  }
 }
 async function deployPreview(gacFilename, deployConfig) {
   const {

--- a/bin/action.min.js
+++ b/bin/action.min.js
@@ -92931,6 +92931,49 @@ exports.getExecOutput = getExecOutput;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+function getChannelId(configuredChannelId, ghContext) {
+  let tmpChannelId = "";
+  if (!!configuredChannelId) {
+    tmpChannelId = configuredChannelId;
+  } else if (ghContext.payload.pull_request) {
+    const branchName = ghContext.payload.pull_request.head.ref.substr(0, 20);
+    tmpChannelId = `pr${ghContext.payload.pull_request.number}-${branchName}`;
+  }
+  // Channel IDs can only include letters, numbers, underscores, hyphens, and periods.
+  const invalidCharactersRegex = /[^a-zA-Z0-9_\-\.]/g;
+  const correctedChannelId = tmpChannelId.replace(invalidCharactersRegex, "_");
+  if (correctedChannelId !== tmpChannelId) {
+    console.log(`ChannelId "${tmpChannelId}" contains unsupported characters. Using "${correctedChannelId}" instead.`);
+  }
+  return correctedChannelId;
+}
+/**
+ * Extracts the channel ID from the channel name
+ * @param channelName
+ * @returns channelId
+ *  Example channelName: projects/my-project/sites/test-staging/channels/pr123-my-branch
+ */
+function extractChannelIdFromChannelName(channelName) {
+  const parts = channelName.split("/");
+  const channelIndex = parts.indexOf("channels") + 1; // The part after "channels"
+  return parts[channelIndex]; // Returns the channel name after "channels/"
+}
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 function interpretChannelDeployResult(deployResult) {
   const allSiteResults = Object.values(deployResult.result);
   const expireTime = allSiteResults[0].expireTime;
@@ -92976,7 +93019,75 @@ async function execWithCredentials(args, projectId, gacFilename, opts) {
   }
   return deployOutputBuf.length ? deployOutputBuf[deployOutputBuf.length - 1].toString("utf-8") : ""; // output from the CLI
 }
-
+async function getAllChannels(gacFilename, deployConfig) {
+  const {
+    projectId,
+    target,
+    firebaseToolsVersion
+  } = deployConfig;
+  const allChannelsText = await execWithCredentials(["hosting:channel:list", ...(target ? ["--site", target] : [])], projectId, gacFilename, {
+    firebaseToolsVersion
+  });
+  const channelResults = JSON.parse(allChannelsText.trim());
+  if (channelResults.status === "error") {
+    throw Error(channelResults.error);
+  } else {
+    return channelResults.channels || [];
+  }
+}
+function getPreviewChannelToRemove(channels, totalPreviewChannelLimit) {
+  // Filter out live channel(hosting default site) and channels without an expireTime(additional sites)
+  const previewChannelsOnly = channels.filter(channel => {
+    var _channel$labels;
+    return (channel == null || (_channel$labels = channel.labels) == null ? void 0 : _channel$labels.type) !== "live" && !!(channel != null && channel.expireTime);
+  });
+  if (previewChannelsOnly.length) {
+    // Sort preview channels by expireTime
+    const sortedPreviewChannels = previewChannelsOnly.sort((channelA, channelB) => {
+      return new Date(channelA.expireTime).getTime() - new Date(channelB.expireTime).getTime();
+    });
+    // If the total number of preview channels exceeds the limit, return the ones with earlier expireTime
+    if (sortedPreviewChannels.length > totalPreviewChannelLimit) {
+      return sortedPreviewChannels.slice(0, sortedPreviewChannels.length - totalPreviewChannelLimit);
+    }
+  } else {
+    return [];
+  }
+}
+/**
+ * Removes preview channels from the list of active channels if the number exceeds the configured limit
+ *
+ * This function identifies the preview channels that need to be removed based on the total limit of
+ * preview channels allowed (`totalPreviewChannelLimit`).
+ *
+ * It then attempts to remove those channels using the `removeChannel` function.
+ * Errors encountered while removing channels are logged but do not stop the execution of removing other channels.
+ */
+async function removePreviews({
+  channels,
+  gacFilename,
+  deployConfig
+}) {
+  const toRemove = getPreviewChannelToRemove(channels, deployConfig.totalPreviewChannelLimit);
+  if (toRemove.length) {
+    await Promise.all(toRemove.map(async channel => {
+      try {
+        await removeChannel(gacFilename, deployConfig, extractChannelIdFromChannelName(channel.name));
+      } catch (error) {
+        console.error(`Error removing preview channel ${channel.name}:`, error);
+      }
+    }));
+  }
+}
+function removeChannel(gacFilename, deployConfig, channelId) {
+  const {
+    projectId,
+    firebaseToolsVersion
+  } = deployConfig;
+  return execWithCredentials(["hosting:channel:delete", channelId, "--force"], projectId, gacFilename, {
+    firebaseToolsVersion
+  });
+}
 async function deployPreview(gacFilename, deployConfig) {
   const {
     projectId,
@@ -93002,38 +93113,6 @@ async function deployProductionSite(gacFilename, productionDeployConfig) {
   });
   const deploymentResult = JSON.parse(deploymentText);
   return deploymentResult;
-}
-
-/**
- * Copyright 2020 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-function getChannelId(configuredChannelId, ghContext) {
-  let tmpChannelId = "";
-  if (!!configuredChannelId) {
-    tmpChannelId = configuredChannelId;
-  } else if (ghContext.payload.pull_request) {
-    const branchName = ghContext.payload.pull_request.head.ref.substr(0, 20);
-    tmpChannelId = `pr${ghContext.payload.pull_request.number}-${branchName}`;
-  }
-  // Channel IDs can only include letters, numbers, underscores, hyphens, and periods.
-  const invalidCharactersRegex = /[^a-zA-Z0-9_\-\.]/g;
-  const correctedChannelId = tmpChannelId.replace(invalidCharactersRegex, "_");
-  if (correctedChannelId !== tmpChannelId) {
-    console.log(`ChannelId "${tmpChannelId}" contains unsupported characters. Using "${correctedChannelId}" instead.`);
-  }
-  return correctedChannelId;
 }
 
 /**
@@ -93182,6 +93261,7 @@ const entryPoint = core.getInput("entryPoint");
 const target = core.getInput("target");
 const firebaseToolsVersion = core.getInput("firebaseToolsVersion");
 const disableComment = core.getInput("disableComment");
+const totalPreviewChannelLimit = Number(core.getInput("totalPreviewChannelLimit") || "0");
 async function run() {
   const isPullRequest = !!github.context.payload.pull_request;
   let finish = details => console.log(details);
@@ -93232,6 +93312,26 @@ async function run() {
       return;
     }
     const channelId = getChannelId(configuredChannelId, github.context);
+    if (totalPreviewChannelLimit) {
+      core.startGroup(`Start counting total Firebase preview channel ${channelId}`);
+      const allChannels = await getAllChannels(gacFilename, {
+        projectId,
+        target,
+        firebaseToolsVersion,
+        totalPreviewChannelLimit
+      });
+      if (allChannels.length) {
+        await removePreviews({
+          channels: allChannels,
+          gacFilename,
+          deployConfig: {
+            projectId,
+            target,
+            firebaseToolsVersion
+          }
+        });
+      }
+    }
     core.startGroup(`Deploying to Firebase preview channel ${channelId}`);
     const deployment = await deployPreview(gacFilename, {
       projectId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/jest": "^29.5.1",
         "@types/tmp": "^0.2.3",
         "babel-jest": "^29.5.0",
-        "husky": "^9.0.11",
+        "husky": "^9.1.7",
         "jest": "^29.5.0",
         "microbundle": "^0.15.1",
         "prettier": "^2.8.7",
@@ -5301,12 +5301,12 @@
       }
     },
     "node_modules/husky": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
-      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
       "bin": {
-        "husky": "bin.mjs"
+        "husky": "bin.js"
       },
       "engines": {
         "node": ">=18"
@@ -15765,9 +15765,9 @@
       "dev": true
     },
     "husky": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
-      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true
     },
     "icss-replace-symbols": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,8 @@
         "husky": "^9.1.7",
         "jest": "^29.5.0",
         "microbundle": "^0.15.1",
-        "prettier": "^2.8.7",
-        "pretty-quick": "^3.3.1",
+        "prettier": "^3.4.1",
+        "pretty-quick": "^4.0.0",
         "tmp": "^0.2.1",
         "ts-jest": "^29.1.3",
         "ts-node": "^10.9.1",
@@ -4577,15 +4577,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
     "node_modules/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
@@ -5290,15 +5281,6 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
-    },
-    "node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.12.0"
-      }
     },
     "node_modules/husky": {
       "version": "9.1.7",
@@ -10036,15 +10018,15 @@
       "dev": true
     },
     "node_modules/prettier": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
-      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.1.tgz",
+      "integrity": "sha512-G+YdqtITVZmOJje6QkXQWzl3fSfMxFwm1tjTyo9exhkmWSqC4Yhd1+lug++IlR2mvRVAxEDDWYkQdeSztajqgg==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -10089,13 +10071,13 @@
       }
     },
     "node_modules/pretty-quick": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-3.3.1.tgz",
-      "integrity": "sha512-3b36UXfYQ+IXXqex6mCca89jC8u0mYLqFAN5eTQKoXO6oCQYcIVYZEB/5AlBHI7JPYygReM2Vv6Vom/Gln7fBg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-4.0.0.tgz",
+      "integrity": "sha512-M+2MmeufXb/M7Xw3Afh1gxcYpj+sK0AxEfnfF958ktFeAyi5MsKY5brymVURQLgPLV1QaF5P4pb2oFJ54H3yzQ==",
       "dev": true,
       "dependencies": {
-        "execa": "^4.1.0",
-        "find-up": "^4.1.0",
+        "execa": "^5.1.1",
+        "find-up": "^5.0.0",
         "ignore": "^5.3.0",
         "mri": "^1.2.0",
         "picocolors": "^1.0.0",
@@ -10103,48 +10085,71 @@
         "tslib": "^2.6.2"
       },
       "bin": {
-        "pretty-quick": "dist/cli.js"
+        "pretty-quick": "lib/cli.mjs"
       },
       "engines": {
-        "node": ">=10.13"
+        "node": ">=14"
       },
       "peerDependencies": {
-        "prettier": "^2.0.0"
+        "prettier": "^3.0.0"
       }
     },
-    "node_modules/pretty-quick/node_modules/execa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+    "node_modules/pretty-quick/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
       },
       "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/pretty-quick/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+    "node_modules/pretty-quick/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "dependencies": {
-        "pump": "^3.0.0"
+        "p-locate": "^5.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pretty-quick/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pretty-quick/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10182,16 +10187,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
       }
     },
     "node_modules/pure-rand": {
@@ -15212,15 +15207,6 @@
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "dev": true
     },
-    "end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
-      "requires": {
-        "once": "^1.4.0"
-      }
-    },
     "entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
@@ -15756,12 +15742,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true
-    },
-    "human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true
     },
     "husky": {
@@ -19279,9 +19259,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
-      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.1.tgz",
+      "integrity": "sha512-G+YdqtITVZmOJje6QkXQWzl3fSfMxFwm1tjTyo9exhkmWSqC4Yhd1+lug++IlR2mvRVAxEDDWYkQdeSztajqgg==",
       "dev": true
     },
     "pretty-bytes": {
@@ -19310,13 +19290,13 @@
       }
     },
     "pretty-quick": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-3.3.1.tgz",
-      "integrity": "sha512-3b36UXfYQ+IXXqex6mCca89jC8u0mYLqFAN5eTQKoXO6oCQYcIVYZEB/5AlBHI7JPYygReM2Vv6Vom/Gln7fBg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-4.0.0.tgz",
+      "integrity": "sha512-M+2MmeufXb/M7Xw3Afh1gxcYpj+sK0AxEfnfF958ktFeAyi5MsKY5brymVURQLgPLV1QaF5P4pb2oFJ54H3yzQ==",
       "dev": true,
       "requires": {
-        "execa": "^4.1.0",
-        "find-up": "^4.1.0",
+        "execa": "^5.1.1",
+        "find-up": "^5.0.0",
         "ignore": "^5.3.0",
         "mri": "^1.2.0",
         "picocolors": "^1.0.0",
@@ -19324,30 +19304,41 @@
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "execa": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
           "dev": true,
           "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
           }
         },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
           "dev": true,
           "requires": {
-            "pump": "^3.0.0"
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
           }
         },
         "picomatch": {
@@ -19372,16 +19363,6 @@
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
-      }
-    },
-    "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
       }
     },
     "pure-rand": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged && npm run build"
+      "pre-commit": "pretty-quick --staged && npm run build && git add bin/*"
     }
   },
   "version": "0.8.0"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "typescript": "^5.0.4"
   },
   "scripts": {
+    "prepare": "husky install",
     "format:check": "prettier . --list-different",
     "format": "prettier --write .",
     "build": "microbundle --format cjs --target node --no-compress --no-sourcemap src/index.ts",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "husky": "^9.1.7",
     "jest": "^29.5.0",
     "microbundle": "^0.15.1",
-    "prettier": "^2.8.7",
-    "pretty-quick": "^3.3.1",
+    "prettier": "^3.4.1",
+    "pretty-quick": "^4.0.0",
     "tmp": "^0.2.1",
     "ts-jest": "^29.1.3",
     "ts-node": "^10.9.1",
@@ -30,10 +30,8 @@
     "format": "prettier --write .",
     "build": "microbundle --format cjs --target node --no-compress --no-sourcemap src/index.ts",
     "build:watch": "microbundle watch --format cjs --target node --no-compress --no-sourcemap src/index.ts",
-    "test": "jest"
-  },
-  "lint-staged": {
-    "**/*": "pretty-quick --staged && npm run build && git add bin/*"
+    "test": "jest",
+    "lint-staged": "pretty-quick --staged && npm run build && git add bin/action.min.js"
   },
   "version": "0.8.0"
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/jest": "^29.5.1",
     "@types/tmp": "^0.2.3",
     "babel-jest": "^29.5.0",
-    "husky": "^9.0.11",
+    "husky": "^9.1.7",
     "jest": "^29.5.0",
     "microbundle": "^0.15.1",
     "prettier": "^2.8.7",
@@ -25,17 +25,15 @@
     "typescript": "^5.0.4"
   },
   "scripts": {
-    "prepare": "husky install",
+    "prepare": "husky",
     "format:check": "prettier . --list-different",
     "format": "prettier --write .",
     "build": "microbundle --format cjs --target node --no-compress --no-sourcemap src/index.ts",
     "build:watch": "microbundle watch --format cjs --target node --no-compress --no-sourcemap src/index.ts",
     "test": "jest"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "pretty-quick --staged && npm run build && git add bin/*"
-    }
+  "lint-staged": {
+    "**/*": "pretty-quick --staged && npm run build && git add bin/*"
   },
   "version": "0.8.0"
 }

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -15,6 +15,7 @@
  */
 
 import { exec } from "@actions/exec";
+import { extractChannelIdFromChannelName } from "./getChannelId";
 
 export type SiteDeploy = {
   site: string;
@@ -27,6 +28,60 @@ export type ErrorResult = {
   status: "error";
   error: string;
 };
+
+export type ChannelTotalSuccessResult = {
+  status: "success";
+  channels: Channel[];
+};
+
+export interface Channel {
+  name: string;
+  url: string;
+  release: {
+    name: string;
+    version: {
+      name: string;
+      status: string;
+      config: {
+        headers: {
+          headers: {
+            "Cache-Control": string;
+          };
+          glob: string;
+        }[];
+        rewrites: {
+          glob: string;
+          path: string;
+        }[];
+      };
+      labels: {
+        "deployment-tool": string;
+      };
+      createTime: string;
+      createUser: {
+        email: string;
+      };
+      finalizeTime: string;
+      finalizeUser: {
+        email: string;
+      };
+      fileCount: string;
+      versionBytes: string;
+    };
+    type: string;
+    releaseTime: string;
+    releaseUser: {
+      email: string;
+    };
+  };
+  createTime: string;
+  updateTime: string;
+  retainedReleaseCount: number;
+  expireTime?: string;
+  labels?: {
+    type: "live";
+  };
+}
 
 export type ChannelSuccessResult = {
   status: "success";
@@ -45,6 +100,8 @@ type DeployConfig = {
   target?: string;
   // Optional version specification for firebase-tools. Defaults to `latest`.
   firebaseToolsVersion?: string;
+  // Optional for preview channels deployment
+  totalPreviewChannelLimit?: number;
 };
 
 export type ChannelDeployConfig = DeployConfig & {
@@ -123,6 +180,120 @@ async function execWithCredentials(
   return deployOutputBuf.length
     ? deployOutputBuf[deployOutputBuf.length - 1].toString("utf-8")
     : ""; // output from the CLI
+}
+
+export async function getAllChannels(
+  gacFilename: string,
+  deployConfig: Omit<ChannelDeployConfig, "expires" | "channelId">
+): Promise<Channel[]> {
+  const { projectId, target, firebaseToolsVersion } = deployConfig;
+
+  const allChannelsText = await execWithCredentials(
+    ["hosting:channel:list", ...(target ? ["--site", target] : [])],
+    projectId,
+    gacFilename,
+    { firebaseToolsVersion }
+  );
+
+  const channelResults = JSON.parse(allChannelsText.trim()) as
+    | ChannelTotalSuccessResult
+    | ErrorResult;
+
+  if (channelResults.status === "error") {
+    throw Error((channelResults as ErrorResult).error);
+  } else {
+    return channelResults.channels || [];
+  }
+}
+
+function getPreviewChannelToRemove(
+  channels: Channel[],
+  totalPreviewChannelLimit: DeployConfig["totalPreviewChannelLimit"]
+): Channel[] {
+  // Filter out live channel(hosting default site) and channels without an expireTime(additional sites)
+  const previewChannelsOnly = channels.filter(
+    (channel) => channel?.labels?.type !== "live" && !!channel?.expireTime
+  );
+
+  if (previewChannelsOnly.length) {
+    // Sort preview channels by expireTime
+    const sortedPreviewChannels = previewChannelsOnly.sort(
+      (channelA, channelB) => {
+        return (
+          new Date(channelA.expireTime).getTime() -
+          new Date(channelB.expireTime).getTime()
+        );
+      }
+    );
+
+    // If the total number of preview channels exceeds the limit, return the ones with earlier expireTime
+    if (sortedPreviewChannels.length > totalPreviewChannelLimit) {
+      return sortedPreviewChannels.slice(
+        0,
+        sortedPreviewChannels.length - totalPreviewChannelLimit
+      );
+    }
+  } else {
+    return [];
+  }
+}
+
+/**
+ * Removes preview channels from the list of active channels if the number exceeds the configured limit
+ *
+ * This function identifies the preview channels that need to be removed based on the total limit of
+ * preview channels allowed (`totalPreviewChannelLimit`).
+ *
+ * It then attempts to remove those channels using the `removeChannel` function.
+ * Errors encountered while removing channels are logged but do not stop the execution of removing other channels.
+ */
+export async function removePreviews({
+  channels,
+  gacFilename,
+  deployConfig,
+}: {
+  channels: Channel[];
+  gacFilename: string;
+  deployConfig: Omit<ChannelDeployConfig, "expires" | "channelId">;
+}) {
+  const toRemove = getPreviewChannelToRemove(
+    channels,
+    deployConfig.totalPreviewChannelLimit
+  );
+
+  if (toRemove.length) {
+    await Promise.all(
+      toRemove.map(async (channel) => {
+        try {
+          await removeChannel(
+            gacFilename,
+            deployConfig,
+            extractChannelIdFromChannelName(channel.name)
+          );
+        } catch (error) {
+          console.error(
+            `Error removing preview channel ${channel.name}:`,
+            error
+          );
+        }
+      })
+    );
+  }
+}
+
+export function removeChannel(
+  gacFilename: string,
+  deployConfig: Omit<ChannelDeployConfig, "expires" | "channelId">,
+  channelId: string
+): Promise<string> {
+  const { projectId, firebaseToolsVersion } = deployConfig;
+
+  return execWithCredentials(
+    ["hosting:channel:delete", channelId, "--force"],
+    projectId,
+    gacFilename,
+    { firebaseToolsVersion }
+  );
 }
 
 export async function deployPreview(

--- a/src/getChannelId.ts
+++ b/src/getChannelId.ts
@@ -37,3 +37,15 @@ export function getChannelId(configuredChannelId: string, ghContext: Context) {
 
   return correctedChannelId;
 }
+
+/**
+ * Extracts the channel ID from the channel name
+ * @param channelName
+ * @returns channelId
+ *  Example channelName: projects/my-project/sites/test-staging/channels/pr123-my-branch
+ */
+export function extractChannelIdFromChannelName(channelName: string): string {
+  const parts = channelName.split("/");
+  const channelIndex = parts.indexOf("channels") + 1; // The part after "channels"
+  return parts[channelIndex]; // Returns the channel name after "channels/"
+}


### PR DESCRIPTION
Part of the solution for https://github.com/FirebaseExtended/action-hosting-deploy/issues/60
- I also would like to make another PR to solve the above issue once this is approved and merged, like the "removeChannel" would be useful.
- Also, the existing "pre-commit" hooks don't really work, made improvement and fix the issue

### **What’s Changed:**

1. **Added `totalPreviewChannelLimit` Input Option**:
   - **Where**: `action.yml`, `README.md`
   - I added a new input to control the number of preview channels Firebase Hosting will use. By setting the `totalPreviewChannelLimit`, you can avoid hitting the hosting quota limit (currently set at 50 channels). 
   - Once the limit is hit, older preview channels get automatically removed, preventing errors like "channel quota reached."

2. **New Function for Managing Preview Channels**:
   - **Where**: `src/deploy.ts`
   - Introduced the `getAllChannels` function to list all active preview channels in the Firebase project, making it easier to track the quota.
   - Added `removePreviews`, which removes older preview channels when the `totalPreviewChannelLimit` is reached. It uses the `removeChannel` function to delete specific channels.
   - The `removeChannel` function allows the deletion of specific preview channels by their ID, helping manage the number of active channels.


3. **Docs Updates**:
   - **Where**: `README.md`, `action.yml`
   - We updated the documentation to include the new `totalPreviewChannelLimit` option, explaining how to set it up and how it interacts with Firebase Hosting’s limits.

### **Why This Matters:**
The goal of this change is to give you more control over Firebase Hosting preview channels. Now, you can prevent hitting the 50-channel limit by automatically cleaning up older channels when necessary, saving you from unexpected errors in your deployment process.
