### PR TITLE
feat: make firebaseServiceAccount input optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ jobs:
 
 ## Options
 
-### `firebaseServiceAccount` _{string}_ (required)
+### `firebaseServiceAccount` _{string}_
 
 This is a service account JSON key. The easiest way to set it up is to run `firebase init hosting:github`. However, it can also be [created manually](./docs/service-account.md).
 
@@ -94,6 +94,8 @@ It's important to store this token as an
 to prevent unintended access to your Firebase project. Set it in the "Secrets" area
 of your repository settings and add it as `FIREBASE_SERVICE_ACCOUNT`:
 `https://github.com/USERNAME/REPOSITORY/settings/secrets`.
+
+If not provided, the action will attempt to use the default application credentials configured in your environment.  
 
 ### `repoToken` _{string}_
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ to prevent unintended access to your Firebase project. Set it in the "Secrets" a
 of your repository settings and add it as `FIREBASE_SERVICE_ACCOUNT`:
 `https://github.com/USERNAME/REPOSITORY/settings/secrets`.
 
-If not provided, the action will attempt to use the default application credentials configured in your environment.  
+If not provided, the action will attempt to use the default application credentials configured in your environment.
 
 ### `repoToken` _{string}_
 

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     required: false
   firebaseServiceAccount:
     description: "Firebase service account JSON"
-    required: true
+    required: false
   expires:
     description: "How long should a preview live? See the preview channels docs for options"
     default: "7d"

--- a/bin/action.min.js
+++ b/bin/action.min.js
@@ -92962,8 +92962,8 @@ async function execWithCredentials(args, projectId, gacFilename, opts) {
         ...process.env,
         FIREBASE_DEPLOY_AGENT: "action-hosting-deploy",
         ...(gacFilename ? {
-          GOOGLE_APPLICATION_CREDENTIALS: gacFilename
-        } : {}) // the CLI will automatically authenticate with this env variable set
+          GOOGLE_APPLICATION_CREDENTIALS: gacFilename // the CLI will automatically authenticate with this env variable set
+        } : {})
       }
     });
   } catch (e) {

--- a/bin/action.min.js
+++ b/bin/action.min.js
@@ -92962,8 +92962,9 @@ async function execWithCredentials(args, projectId, gacFilename, opts) {
         ...process.env,
         FIREBASE_DEPLOY_AGENT: "action-hosting-deploy",
         ...(gacFilename ? {
-          GOOGLE_APPLICATION_CREDENTIALS: gacFilename // the CLI will automatically authenticate with this env variable set
-        } : {})
+          GOOGLE_APPLICATION_CREDENTIALS: gacFilename
+        } // the CLI will automatically authenticate with this env variable set
+        : {})
       }
     });
   } catch (e) {
@@ -93282,5 +93283,3 @@ async function run() {
   }
 }
 run();
-
-exports.run = run;

--- a/bin/action.min.js
+++ b/bin/action.min.js
@@ -91689,6 +91689,9 @@ module.exports.setGracefulCleanup = setGracefulCleanup;
 // Set up Google Application Credentials for use by the Firebase CLI
 // https://cloud.google.com/docs/authentication/production#finding_credentials_automatically
 async function createGacFile(googleApplicationCredentials) {
+  if (!googleApplicationCredentials) {
+    return "";
+  }
   const tmpFile = tmp.fileSync({
     postfix: ".json"
   });
@@ -92958,7 +92961,9 @@ async function execWithCredentials(args, projectId, gacFilename, opts) {
       env: {
         ...process.env,
         FIREBASE_DEPLOY_AGENT: "action-hosting-deploy",
-        GOOGLE_APPLICATION_CREDENTIALS: gacFilename // the CLI will automatically authenticate with this env variable set
+        ...(gacFilename ? {
+          GOOGLE_APPLICATION_CREDENTIALS: gacFilename
+        } : {}) // the CLI will automatically authenticate with this env variable set
       }
     });
   } catch (e) {
@@ -92976,7 +92981,6 @@ async function execWithCredentials(args, projectId, gacFilename, opts) {
   }
   return deployOutputBuf.length ? deployOutputBuf[deployOutputBuf.length - 1].toString("utf-8") : ""; // output from the CLI
 }
-
 async function deployPreview(gacFilename, deployConfig) {
   const {
     projectId,
@@ -93171,9 +93175,7 @@ async function postChannelSuccessComment(github, context, result, commit) {
 // Inputs defined in action.yml
 const expires = core.getInput("expires");
 const projectId = core.getInput("projectId");
-const googleApplicationCredentials = core.getInput("firebaseServiceAccount", {
-  required: true
-});
+const googleApplicationCredentials = core.getInput("firebaseServiceAccount");
 const configuredChannelId = core.getInput("channelId");
 const isProductionDeploy = configuredChannelId === "live";
 const token = process.env.GITHUB_TOKEN || core.getInput("repoToken");
@@ -93280,3 +93282,5 @@ async function run() {
   }
 }
 run();
+
+exports.run = run;

--- a/src/createGACFile.ts
+++ b/src/createGACFile.ts
@@ -20,8 +20,11 @@ import { writeSync } from "fs";
 // Set up Google Application Credentials for use by the Firebase CLI
 // https://cloud.google.com/docs/authentication/production#finding_credentials_automatically
 export async function createGacFile(googleApplicationCredentials: string) {
-  const tmpFile = fileSync({ postfix: ".json" });
+  if (!googleApplicationCredentials) {
+    return "";
+  }
 
+  const tmpFile = fileSync({ postfix: ".json" });
   writeSync(tmpFile.fd, googleApplicationCredentials);
 
   return tmpFile.name;

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -99,7 +99,9 @@ async function execWithCredentials(
         env: {
           ...process.env,
           FIREBASE_DEPLOY_AGENT: "action-hosting-deploy",
-          GOOGLE_APPLICATION_CREDENTIALS: gacFilename, // the CLI will automatically authenticate with this env variable set
+          ...(gacFilename
+            ? { GOOGLE_APPLICATION_CREDENTIALS: gacFilename }
+            : {}), // the CLI will automatically authenticate with this env variable set
         },
       }
     );

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -100,8 +100,8 @@ async function execWithCredentials(
           ...process.env,
           FIREBASE_DEPLOY_AGENT: "action-hosting-deploy",
           ...(gacFilename
-            ? { GOOGLE_APPLICATION_CREDENTIALS: gacFilename }
-            : {}), // the CLI will automatically authenticate with this env variable set
+            ? { GOOGLE_APPLICATION_CREDENTIALS: gacFilename } // the CLI will automatically authenticate with this env variable set
+            : {}),
         },
       }
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ const target = getInput("target");
 const firebaseToolsVersion = getInput("firebaseToolsVersion");
 const disableComment = getInput("disableComment");
 
-export async function run() {
+async function run() {
   const isPullRequest = !!context.payload.pull_request;
 
   let finish = (details: Object) => console.log(details);

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,9 +40,7 @@ import {
 // Inputs defined in action.yml
 const expires = getInput("expires");
 const projectId = getInput("projectId");
-const googleApplicationCredentials = getInput("firebaseServiceAccount", {
-  required: true,
-});
+const googleApplicationCredentials = getInput("firebaseServiceAccount");
 const configuredChannelId = getInput("channelId");
 const isProductionDeploy = configuredChannelId === "live";
 const token = process.env.GITHUB_TOKEN || getInput("repoToken");
@@ -52,7 +50,7 @@ const target = getInput("target");
 const firebaseToolsVersion = getInput("firebaseToolsVersion");
 const disableComment = getInput("disableComment");
 
-async function run() {
+export async function run() {
   const isPullRequest = !!context.payload.pull_request;
 
   let finish = (details: Object) => console.log(details);


### PR DESCRIPTION
### Key Changes:
1. **Optional firebaseServiceAccount Input**:
The firebaseServiceAccount input is no longer required. If not provided, the action defaults to using the Application Default Credentials (ADC) available in the GitHub Actions environment. This reduces the need for explicitly managing and passing a service account key JSON file.

```yaml
jobs:
  demos:
    runs-on: ubuntu-latest
    permissions:
      contents: "read"
      id-token: "write"

    steps:
      - uses: actions/checkout@v4
      - uses: google-github-actions/auth@v2
        with:
          project_id: ${{ vars.PROJECT_ID }}
          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_FEDERATION_PROVIDER_ID }}
          service_account: ${{ vars.SERVICE_ACCOUNT }}

      - uses: FirebaseExtended/action-hosting-deploy@main
        with:
          # firebaseServiceAccount: CAN_BE_OMITTED
          projectId: ${{ vars.PROJECT_ID }}
          channelId: live
          entryPoint: ./demo
```

### Expected Outcomes
1. **Improved Security**:
By leveraging default credentials, this change minimizes the usage of static key JSON files, which can pose security risks if mishandled or exposed.
2. **Simplified Workflow Configuration**:
Users can now avoid creating and storing a firebaseServiceAccount secret unless explicitly needed, streamlining the setup process and reducing overhead.
3. **Backward Compatibility**:
Existing workflows that supply a firebaseServiceAccount key JSON will continue to function as before, with no changes required.