### PR TITLE
fix: empty channelId in test environment

### DIFF
--- a/bin/action.min.js
+++ b/bin/action.min.js
@@ -93030,6 +93030,12 @@ function getChannelId(configuredChannelId, ghContext) {
   // Channel IDs can only include letters, numbers, underscores, hyphens, and periods.
   const invalidCharactersRegex = /[^a-zA-Z0-9_\-\.]/g;
   const correctedChannelId = tmpChannelId.replace(invalidCharactersRegex, "_");
+
+  console.log(`configuredChannelId :"${configuredChannelId}"`);
+  console.log(`tmpChannelId :"${tmpChannelId}"`);
+  console.log(`correctedChannelId :"${correctedChannelId}"`);
+  console.log("ghContext :", ghContext);
+
   if (correctedChannelId !== tmpChannelId) {
     console.log(`ChannelId "${tmpChannelId}" contains unsupported characters. Using "${correctedChannelId}" instead.`);
   }

--- a/bin/action.min.js
+++ b/bin/action.min.js
@@ -92976,7 +92976,6 @@ async function execWithCredentials(args, projectId, gacFilename, opts) {
   }
   return deployOutputBuf.length ? deployOutputBuf[deployOutputBuf.length - 1].toString("utf-8") : ""; // output from the CLI
 }
-
 async function deployPreview(gacFilename, deployConfig) {
   const {
     projectId,
@@ -93026,16 +93025,12 @@ function getChannelId(configuredChannelId, ghContext) {
   } else if (ghContext.payload.pull_request) {
     const branchName = ghContext.payload.pull_request.head.ref.substr(0, 20);
     tmpChannelId = `pr${ghContext.payload.pull_request.number}-${branchName}`;
+  } else {
+    throw Error(`ChannelId is empty. No branch was found in the current context. Please provide a channelId for test environments.`);
   }
   // Channel IDs can only include letters, numbers, underscores, hyphens, and periods.
   const invalidCharactersRegex = /[^a-zA-Z0-9_\-\.]/g;
   const correctedChannelId = tmpChannelId.replace(invalidCharactersRegex, "_");
-
-  console.log(`configuredChannelId :"${configuredChannelId}"`);
-  console.log(`tmpChannelId :"${tmpChannelId}"`);
-  console.log(`correctedChannelId :"${correctedChannelId}"`);
-  console.log("ghContext :", ghContext);
-
   if (correctedChannelId !== tmpChannelId) {
     console.log(`ChannelId "${tmpChannelId}" contains unsupported characters. Using "${correctedChannelId}" instead.`);
   }

--- a/src/getChannelId.ts
+++ b/src/getChannelId.ts
@@ -35,5 +35,11 @@ export function getChannelId(configuredChannelId: string, ghContext: Context) {
     );
   }
 
+  if (correctedChannelId.length == 0) {
+    throw Error(
+      `ChannelId is empty. No branch was found in the current context. Please provide a channelId for testing.`
+    );
+  }
+
   return correctedChannelId;
 }

--- a/src/getChannelId.ts
+++ b/src/getChannelId.ts
@@ -37,7 +37,7 @@ export function getChannelId(configuredChannelId: string, ghContext: Context) {
   
   if (correctedChannelId !== tmpChannelId) {
     console.log(
-      `ChannelId "${tmpChannelId}" contains unsupported characters. Using "${correctedChannelId}" instead.`
+      `ChannelId "${tmpChannelId}" contains unsupported characters. Using "${correctedChannelId}" instead, ${configuredChannelId}.`
     );
   }
 

--- a/src/getChannelId.ts
+++ b/src/getChannelId.ts
@@ -24,26 +24,19 @@ export function getChannelId(configuredChannelId: string, ghContext: Context) {
   } else if (ghContext.payload.pull_request) {
     const branchName = ghContext.payload.pull_request.head.ref.substr(0, 20);
     tmpChannelId = `pr${ghContext.payload.pull_request.number}-${branchName}`;
+  } else {
+    throw Error(
+      `ChannelId is empty. No branch was found in the current context. Please provide a channelId for test environments.`
+    );
   }
 
   // Channel IDs can only include letters, numbers, underscores, hyphens, and periods.
   const invalidCharactersRegex = /[^a-zA-Z0-9_\-\.]/g;
   const correctedChannelId = tmpChannelId.replace(invalidCharactersRegex, "_");
 
-  console.log(`configuredChannelId :"${configuredChannelId}"`);
-  console.log(`tmpChannelId :"${tmpChannelId}"`);
-  console.log(`correctedChannelId :"${correctedChannelId}"`);
-  console.log("ghContext :", ghContext);
-  
   if (correctedChannelId !== tmpChannelId) {
     console.log(
-      `ChannelId "${tmpChannelId}" contains unsupported characters. Using "${correctedChannelId}" instead, ${configuredChannelId}.`
-    );
-  }
-
-  if (correctedChannelId.length == 0) {
-    throw Error(
-      `ChannelId is empty. No branch was found in the current context. Please provide a channelId for testing.`
+      `ChannelId "${tmpChannelId}" contains unsupported characters. Using "${correctedChannelId}" instead.`
     );
   }
 

--- a/src/getChannelId.ts
+++ b/src/getChannelId.ts
@@ -29,6 +29,9 @@ export function getChannelId(configuredChannelId: string, ghContext: Context) {
   // Channel IDs can only include letters, numbers, underscores, hyphens, and periods.
   const invalidCharactersRegex = /[^a-zA-Z0-9_\-\.]/g;
   const correctedChannelId = tmpChannelId.replace(invalidCharactersRegex, "_");
+
+  console.table({configuredChannelId, tmpChannelId, invalidCharactersRegex, correctedChannelId});
+  
   if (correctedChannelId !== tmpChannelId) {
     console.log(
       `ChannelId "${tmpChannelId}" contains unsupported characters. Using "${correctedChannelId}" instead.`

--- a/src/getChannelId.ts
+++ b/src/getChannelId.ts
@@ -30,7 +30,10 @@ export function getChannelId(configuredChannelId: string, ghContext: Context) {
   const invalidCharactersRegex = /[^a-zA-Z0-9_\-\.]/g;
   const correctedChannelId = tmpChannelId.replace(invalidCharactersRegex, "_");
 
-  console.table({configuredChannelId, tmpChannelId, invalidCharactersRegex, correctedChannelId});
+  console.log(`configuredChannelId :"${configuredChannelId}"`);
+  console.log(`tmpChannelId :"${tmpChannelId}"`);
+  console.log(`correctedChannelId :"${correctedChannelId}"`);
+  console.log("ghContext :", ghContext);
   
   if (correctedChannelId !== tmpChannelId) {
     console.log(


### PR DESCRIPTION
Hi,

I figured out that the problem I was having in https://github.com/FirebaseExtended/action-hosting-deploy/issues/403 was occurring because I was using [act](https://github.com/nektos/act). But i then saw that there is no default case in the `getChannelId` function.

By adding this `else` statement, I'm ensuring that the channelId has a valid value before passing it to `firebase-tools`, otherwise errors will occur and it's hard to debug.

Now, here is the error I get when not using a channelId in a test environment:
```js
{
  conclusion: 'failure',
  output: {
    title: 'Deploy preview failed',
    summary: 'Error: ChannelId is empty. No branch was found in the current context. Please provide a channelId for test environments.'
  }
}
```

And of course, according to the guidelines I've run:
```js
npm run format:check

npm run build

npm run test
```

before opening the PR :)

I'm available for any changes or questions, I hope everything sounds good to you.