### PR TITLE
docs: updating github action permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ on:
 jobs:
   deploy_live_website:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
     steps:
       - uses: actions/checkout@v2
       # Add any build steps here. For example:


### PR DESCRIPTION
by default action will fail if no permissions is given trough github webUI or permissions configuration