### PR TITLE
chore: bump action runtime to Node 24 (fixes #448)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ branding:
   icon: "globe"
   color: "blue"
 runs:
-  using: "node20"
+  using: "node24"
   main: "bin/action.min.js"
 inputs:
   repoToken:


### PR DESCRIPTION
## Summary

Fixes #448.

GitHub will force all Node-20 JavaScript actions onto Node 24 on **June 2nd 2026** and surfaces a deprecation annotation on every run in the meantime. Every \`action-hosting-deploy\` invocation today emits:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: FirebaseExtended/action-hosting-deploy@…

This PR bumps \`runs.using\` from \`node20\` → \`node24\` in \`action.yml\` so the warning goes away and we're on the other side of the forced cutover. That's the only line that changes.

## Scope (deliberately minimal)

- Single-line change in \`action.yml\`.
- \`npm run build\` rebuilds cleanly and produces a **byte-identical** \`bin/action.min.js\` (the runtime declaration doesn't affect microbundle's output, which is already \`--target node\`). The \`check-build.yml\` workflow's \`git diff --exit-code\` on \`*.min.js\` should pass.
- \`npm run format:check\` clean.
- \`npm run test\` — 13 passed, 0 failed.
- No source, dependency, or API changes.
- No consumer-side change required; workflows using \`FirebaseExtended/action-hosting-deploy@v0\` keep working.

## Verification

\`\`\`
$ npm run format:check
(clean)

$ npm run build
Build "firebase-hosting-preview-action" to bin:
       177 kB: action.min.js.gz
       126 kB: action.min.js.br

$ git diff --stat -- "*.min.js"
(empty)

$ npm run test
Test Suites: 3 passed, 3 total
Tests:       13 passed, 13 total
\`\`\`

## Notes for the reviewer

- Node 24 is the version GitHub will force runtime to on June 2nd 2026 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The currently-in-flight \`ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION\` escape hatch is explicitly temporary, so moving now is the cleanest path.
- Issue #440 ("Support Node 24") is the same ask from a bug angle — this PR closes both.
- CLA: I'll sign the Google CLA when the check runs if I haven't already.

## Checklist

- [x] \`npm run format:check\`
- [x] \`npm run build\` — bundle unchanged
- [x] \`npm run test\` — 13/13 pass
- [x] No consumer workflow breakage (action input/output surface untouched)